### PR TITLE
메인 페이지 레이아웃 관련 PR입니다.

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,2 +1,10 @@
 body {
 }
+
+#ad-banner-wrap {
+  width: 1224px;
+  height: 200px;
+  border: 1px solid black;
+  border-radius: 12px;
+  margin-bottom: 44px;
+}

--- a/css/main/main.css
+++ b/css/main/main.css
@@ -1,0 +1,6 @@
+body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/css/main/main.css
+++ b/css/main/main.css
@@ -1,3 +1,0 @@
-body {
-  background: black;
-}

--- a/css/main/movie.css
+++ b/css/main/movie.css
@@ -1,25 +1,69 @@
 #movie-wrap {
   width: 1224px;
+  border: 1px solid black;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   gap: 22px;
+  border-radius: 12px;
+  padding: 20px 0px 20px 0px;
+  margin-bottom: 44px;
 }
 
 #movie-title-wrap {
   display: flex;
+  justify-content: space-between;
+  padding: 0px 18px 0px 18px;
 }
 
 #top-rated-movies-wrap {
   display: flex;
   gap: 22px;
+  padding: 0px 18px 0px 18px;
 }
 
 #popular-movies-wrap {
   display: flex;
   gap: 22px;
+  padding: 0px 18px 0px 18px;
 }
 
 #upcoming-movies-wrap {
   display: flex;
   gap: 22px;
+  padding: 0px 18px 0px 18px;
+}
+
+.movie-content-wrap {
+  line-height: 1.5;
+  position: relative;
+  cursor: pointer;
+}
+
+.movie-content-wrap > img {
+  width: 220px;
+  height: 300px;
+  border-radius: 12px;
+}
+
+.movie-content-wrap > h4 {
+  white-space: nowrap;
+  width: 200px;
+}
+
+.movie-vote-average-text {
+}
+
+.movie-release-date-text {
+}
+
+.movie-rank-text {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  padding: 2px 2px 4px 2px;
+  top: 12px;
+  left: 12px;
+  border-radius: 6px;
+  text-align: center;
 }

--- a/css/main/movie.css
+++ b/css/main/movie.css
@@ -1,0 +1,25 @@
+#movie-wrap {
+  width: 1224px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+#movie-title-wrap {
+  display: flex;
+}
+
+#top-rated-movies-wrap {
+  display: flex;
+  gap: 22px;
+}
+
+#popular-movies-wrap {
+  display: flex;
+  gap: 22px;
+}
+
+#upcoming-movies-wrap {
+  display: flex;
+  gap: 22px;
+}

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <script type="module" src="js/main/index.js"></script>
   </head>
   <body>
-    <section id="ad-banner-wrap"></section>
+    <section id="ad-banner-wrap"><p>과아아아아아아앙고배너</p></section>
     <section id="movie-wrap">
       <div id="movie-title-wrap">
         <h2>살면서 한번쯤은 봐야할 영화</h2>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,36 @@
     <script type="module" src="js/main/index.js"></script>
   </head>
   <body>
-    <h1>Hello World!</h1>
+    <section id="ad-banner-wrap"></section>
+    <section id="movie-wrap">
+      <div id="movie-title-wrap">
+        <h2>살면서 한번쯤은 봐야할 영화</h2>
+        <div id="movie-button-wrap">
+          <button><</button>
+          <button>></button>
+        </div>
+      </div>
+      <div id="top-rated-movies-wrap"></div>
+    </section>
+    <section id="movie-wrap">
+      <div id="movie-title-wrap">
+        <h2>인기있는 영화</h2>
+        <div id="movie-button-wrap">
+          <button><</button>
+          <button>></button>
+        </div>
+      </div>
+      <div id="popular-movies-wrap"></div>
+    </section>
+    <section id="movie-wrap">
+      <div id="movie-title-wrap">
+        <h2>개봉예정 영화</h2>
+        <div id="movie-button-wrap">
+          <button><</button>
+          <button>></button>
+        </div>
+      </div>
+      <div id="upcoming-movies-wrap"></div>
+    </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/reset.css" />
     <link rel="stylesheet" href="css/global.css" />
     <link rel="stylesheet" href="css/main/main.css" />
+    <link rel="stylesheet" href="css/main/movie.css" />
     <!-- JS 가져오기 -->
     <script type="module" src="js/main/index.js"></script>
   </head>

--- a/js/main/components/MoviesInfo.js
+++ b/js/main/components/MoviesInfo.js
@@ -1,4 +1,4 @@
-import { TMDB_IMAGE_URL } from "../../config/constants";
+import { TMDB_IMAGE_URL } from "../../config/constants/index.js";
 
 export default function MoviesInfo(data) {
   const movieElements = data

--- a/js/main/components/MoviesInfo.js
+++ b/js/main/components/MoviesInfo.js
@@ -1,0 +1,22 @@
+import { TMDB_IMAGE_URL } from "../../config/constants";
+
+export default function MoviesInfo(data) {
+  const movieElements = data
+    .map((movie, idx) => {
+      return `
+      <div id="movie-item-${movie.id}" class="movie-content-wrap">
+        <img src="${TMDB_IMAGE_URL}${movie.poster_path}" />
+        <h4>${movie.title}</h4>
+        <p class="movie-vote-average-text">
+          평점: ${movie.vote_average.toFixed(1)}점
+        </p>
+        <p class="movie-release-date-text">
+         개봉 일자: ${movie.release_date.replace(/-/gi, ".")}
+        </p>
+        <p class="movie-rank-text">${idx + 1}</p>
+    </div>`;
+    })
+    .reduce((acc, cur) => acc + cur, []);
+
+  return movieElements;
+}

--- a/js/main/index.js
+++ b/js/main/index.js
@@ -1,3 +1,4 @@
+import MoviesInfo from "./components/MoviesInfo.js";
 import useMovieData from "./hook/useMovieData.js";
 
 const { getPopularMovies, getTopRatedMovies, getUpcomingMovies } =
@@ -8,3 +9,15 @@ const [popularMovies, topRatedMovies, upcomingMovies] = await Promise.all([
   getTopRatedMovies(1),
   getUpcomingMovies(1),
 ]);
+
+const topRatedMovieElements = MoviesInfo(topRatedMovies);
+const popularMovieElements = MoviesInfo(popularMovies);
+const upcomingMovieElements = MoviesInfo(upcomingMovies);
+
+const topRatedMoviesWrap = document.getElementById("top-rated-movies-wrap");
+const popularMoviesWrap = document.getElementById("popular-movies-wrap");
+const upcomingMoviesWrap = document.getElementById("upcoming-movies-wrap");
+
+topRatedMoviesWrap.innerHTML = topRatedMovieElements;
+popularMoviesWrap.innerHTML = popularMovieElements;
+upcomingMoviesWrap.innerHTML = upcomingMovieElements;


### PR DESCRIPTION
## 추가 🛠️

- 메인 페이지의 전반적인 레이아웃이 추가되었습니다.
- 가져온 데이터를 UI에 표시해주는 로직이 추가되었습니다.
  - 데이터를 가져오고,
  - 가져온 데이터들을 MoviesInfo() 함수에 넣어주면,
  - MoviesInfo() 함수는 인자로 받은 데이터를 바탕으로 UI에 표시해줄 HTML 태그들과 내용들을 생성해 반환해줍니다.
  - 그리고 각 영화들의 데이터가 표시될 id의 element를 가져온 다음,
  - 그 element의 innerHTML을 MoviesInfo() 함수로 받아온 태그들로 바꿔줍니다!

## 변경 🛠️

- 없습니다!